### PR TITLE
Fixed Broken Font Size

### DIFF
--- a/src/ChrisKonnertz/BBCode/BBCode.php
+++ b/src/ChrisKonnertz/BBCode/BBCode.php
@@ -459,10 +459,10 @@ class BBCode
             case self::TAG_NAME_SIZE:
                 if ($tag->opening) {
                     if ($tag->property) {
-                        $code = '<span style="font-size: '.$tag->property.'%">';
+                        $code = '<font size="'.$tag->property.'">';
                     }
                 } else {
-                    $code = '</span>';
+                    $code = '</font>';
                 }
                 break;
             case self::TAG_NAME_COLOR:


### PR DESCRIPTION
BBCode uses size, not percentage. So html tag has to be size, not percentage because there is no algorithm written that will calculate percentage.
So instead of eg.
```<span style="font-size: 7%">```
it has to be
```<font size="7">```
Base char size is 100%, so 7% will make char unreadable due downsizing.